### PR TITLE
quote string in error message

### DIFF
--- a/udp.go
+++ b/udp.go
@@ -76,8 +76,8 @@ func ShouldReceiveOnly(t *testing.T, expected string, body fn) {
 	got, equals, _ := get(t, expected, body)
 	if !equals {
 		printLocation(t)
-		t.Errorf("Expected: %s", expected)
-		t.Errorf("But got: %s", got)
+		t.Errorf("Expected: \"%s\"", expected)
+		t.Errorf("But got: \"%s\"", got)
 	}
 }
 
@@ -87,7 +87,7 @@ func ShouldNotReceiveOnly(t *testing.T, notExpected string, body fn) {
 	_, equals, _ := get(t, notExpected, body)
 	if equals {
 		printLocation(t)
-		t.Errorf("Expected not to get: %s", notExpected)
+		t.Errorf("Expected not to get: \"%s\"", notExpected)
 	}
 }
 
@@ -97,8 +97,8 @@ func ShouldReceive(t *testing.T, expected string, body fn) {
 	got, _, contains := get(t, expected, body)
 	if !contains {
 		printLocation(t)
-		t.Errorf("Expected to find: %s", expected)
-		t.Errorf("But got: %s", got)
+		t.Errorf("Expected to find: \"%s\"", expected)
+		t.Errorf("But got: \"%s\"", got)
 	}
 }
 
@@ -108,8 +108,8 @@ func ShouldNotReceive(t *testing.T, expected string, body fn) {
 	got, _, contains := get(t, expected, body)
 	if contains {
 		printLocation(t)
-		t.Errorf("Expected not to find: %s", expected)
-		t.Errorf("But got: %s", got)
+		t.Errorf("Expected not to find: \"%s\"", expected)
+		t.Errorf("But got: \"%s\"", got)
 	}
 }
 
@@ -125,12 +125,12 @@ func ShouldReceiveAll(t *testing.T, expected []string, body fn) {
 				printLocation(t)
 				failed = true
 			}
-			t.Errorf("Expected to find: %s", str)
+			t.Errorf("Expected to find: \"%s\"", str)
 		}
 	}
 
 	if failed {
-		t.Errorf("But got: %s", got)
+		t.Errorf("But got: \"%s\"", got)
 	}
 }
 
@@ -146,12 +146,12 @@ func ShouldNotReceiveAny(t *testing.T, unexpected []string, body fn) {
 				printLocation(t)
 				failed = true
 			}
-			t.Errorf("Expected not to find: %s", str)
+			t.Errorf("Expected not to find: \"%s\"", str)
 		}
 	}
 
 	if failed {
-		t.Errorf("But got: %s", got)
+		t.Errorf("But got: \"%s\"", got)
 	}
 }
 
@@ -165,7 +165,7 @@ func ShouldReceiveAllAndNotReceiveAny(t *testing.T, expected []string, unexpecte
 				printLocation(t)
 				failed = true
 			}
-			t.Errorf("Expected to find: %s", str)
+			t.Errorf("Expected to find: \"%s\"", str)
 		}
 	}
 	for _, str := range unexpected {
@@ -174,11 +174,11 @@ func ShouldReceiveAllAndNotReceiveAny(t *testing.T, expected []string, unexpecte
 				printLocation(t)
 				failed = true
 			}
-			t.Errorf("Expected not to find: %s", str)
+			t.Errorf("Expected not to find: \"%s\"", str)
 		}
 	}
 
 	if failed {
-		t.Errorf("but got: %s", got)
+		t.Errorf("but got: \"%s\"", got)
 	}
 }


### PR DESCRIPTION
First of all: you did a great job with `go-udp-testing`, it really improved our test scenario's.
## situation

Yesterday I ran in a situation where I got failure messages from an UDP test. But the visual output from the test runner the same:

```
--- FAIL: TestLogentriesBackend-6 (0.00s)
    udp.go:70: At: /home/pjvds/dev/go/src/github.com/pjvds/tidy/logentries/backend_test.go:30
    udp.go:79: Expected: 2bfbea1e-10c3-4419-bdad-7e6435882e1f DEBUG (module): log message
    udp.go:80: But got: 2bfbea1e-10c3-4419-bdad-7e6435882e1f DEBUG (module): log message
```

After some debugging I found that the actual string had leading white spaces.
## proposal

This pull request changes the `expected` and `got` error message format by surrounding the string with quotes (`"`). This was leading white spaces can be spotted easily.

As an example, here is what the failing test looks like after the change:

```
--- FAIL: TestLogentriesBackend-6 (0.00s)
    udp.go:70: At: /home/pjvds/dev/go/src/github.com/pjvds/tidy/logentries/backend_test.go:30
    udp.go:79: Expected: "2bfbea1e-10c3-4419-bdad-7e6435882e1f DEBUG (module): log message"
    udp.go:80: But got: "2bfbea1e-10c3-4419-bdad-7e6435882e1f DEBUG (module): log message   "
```
