### PR TITLE
Remove the goroutine from reading from socket due to race condition

### DIFF
--- a/udp.go
+++ b/udp.go
@@ -44,26 +44,21 @@ func getMessage(t *testing.T, body fn) string {
 	start(t)
 	defer stop(t)
 
-	result := make(chan string)
-
-	go func() {
-		message := make([]byte, 1024*32)
-		var bufLen int
-		for {
-			listener.SetReadDeadline(time.Now().Add(Timeout))
-			n, _, _ := listener.ReadFrom(message[bufLen:])
-			if n == 0 {
-				result <- string(message[0:bufLen])
-				break
-			} else {
-				bufLen += n
-			}
-		}
-	}()
-
 	body()
 
-	return <-result
+	message := make([]byte, 1024*32)
+	var bufLen int
+	for {
+		listener.SetReadDeadline(time.Now().Add(Timeout))
+		n, _, _ := listener.ReadFrom(message[bufLen:])
+		if n == 0 {
+			break
+		} else {
+			bufLen += n
+		}
+	}
+
+	return string(message[0:bufLen])
 }
 
 func get(t *testing.T, match string, body fn) (got string, equals bool, contains bool) {


### PR DESCRIPTION
The goroutine can cause a race condition in cases where your function takes some time before it sends data. Having the data being read in a goroutine made no sense to me so I think removing is fine.

I created a test to show the problem
