### PR TITLE
Support for custom implementation of string matching

### DIFF
--- a/udp.go
+++ b/udp.go
@@ -190,3 +190,7 @@ func ShouldReceiveAllAndNotReceiveAny(t *testing.T, expected []string, unexpecte
 		t.Errorf("but got: %#v", got)
 	}
 }
+
+func ReceiveString(t *testing.T, body fn) string {
+	return getMessage(t, body)
+}


### PR DESCRIPTION
Exporting the `getMessage` by an another function. Helps for custom implementation of string matching as explained [here](https://github.com/stvp/go-udp-testing/issues/5)