### PR TITLE
Add set timeout method

### DIFF
--- a/udp.go
+++ b/udp.go
@@ -23,6 +23,11 @@ func SetAddr(a string) {
 	addr = &a
 }
 
+// SetTimeout sets the UDP read deadline
+func SetTimeout(t int) {
+	Timeout = time.Duration(t) * time.Millisecond
+}
+
 func start(t *testing.T) {
 	resAddr, err := net.ResolveUDPAddr("udp", *addr)
 	if err != nil {


### PR DESCRIPTION
The use case for this method arised when making many successive calls to `ShouldReceiveOnly`. The default `Timeout` of one milisecond was not sufficient as the read deadline, causing packets to be lost. Ultimately, the tests failed in a non-deterministic manner.